### PR TITLE
Fixed exceptions classes.

### DIFF
--- a/Sharpmake.Application/CommandLineArguments.cs
+++ b/Sharpmake.Application/CommandLineArguments.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 using System;
 using System.IO;
+using System.Runtime.Serialization;
 
 namespace Sharpmake.Application
 {
@@ -20,11 +21,15 @@ namespace Sharpmake.Application
     {
         public class Argument
         {
+            [Serializable]
             public class Error : Exception
             {
                 public Error(string message, params object[] args)
                     : base(string.Format(message, args))
                 { }
+
+                protected Error(SerializationInfo info, StreamingContext context)
+                    : base(info, context) { }
             }
 
             public enum InputType

--- a/Sharpmake/DebugProjectGenerator.cs
+++ b/Sharpmake/DebugProjectGenerator.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 
 
@@ -242,9 +243,13 @@ namespace Sharpmake
         }
     }
 
+    [Serializable]
     public class AssemblyVersionException : Exception
     {
         public AssemblyVersionException() : base() { }
         public AssemblyVersionException(string msg) : base(msg) { }
+
+        protected AssemblyVersionException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 }

--- a/Sharpmake/Exception.cs
+++ b/Sharpmake/Exception.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System;
+using System.Runtime.Serialization;
 
 namespace Sharpmake
 {
@@ -44,8 +45,12 @@ namespace Sharpmake
             if (!condition)
                 throw new Error(message, args);
         }
+
+        protected Error(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 
+    [Serializable]
     public class InternalError : Exception
     {
         public InternalError()
@@ -63,6 +68,9 @@ namespace Sharpmake
         public InternalError(Exception innerException, string message, params object[] args)
             : base(String.Format(message, args), innerException)
         { }
+
+        protected InternalError(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
 
         public static void Valid(bool condition)
         {


### PR DESCRIPTION
Properly implemented exceptions according to the guildelines. (See https://blog.gurock.com/articles/creating-custom-exceptions-in-dotnet/)

* All Sharpmake exceptions are now [Serializable].
* All Sharpmake exceptions now have the protected constructor needed for deserialization.

This changelist does *not* put the `Exception` suffix to the Sharpmake exception classes that do not, in case it breaks existing scripts. (Although scripts should not catch Error or InternalError exceptions.)

Tip: Use the built-in code snippet in VS to declare a custom exception class.