### PR TITLE
C++ standard level support for VS

### DIFF
--- a/Sharpmake.Generators/FastBuild/Bff.Template.cs
+++ b/Sharpmake.Generators/FastBuild/Bff.Template.cs
@@ -312,6 +312,7 @@ Compiler( '[fastbuildCompilerName]' )
             + ' [cmdLineOptions.ForceConformanceInForLoopScope]'
             + ' [cmdLineOptions.RuntimeTypeInfo]'
             + ' [cmdLineOptions.OpenMP]'
+            + ' [cmdLineOptions.LanguageStandard]'
             // Output Files options
             // ---------------------------
             + ' [cmdLineOptions.CompilerProgramDatabaseFile]'

--- a/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
+++ b/Sharpmake.Generators/VisualStudio/ProjectOptionsGenerator.cs
@@ -208,6 +208,9 @@ namespace Sharpmake.Generators.VisualStudio
             {
                 context.Options["CharacterSet"] = FileGeneratorUtilities.RemoveLineTag;
                 context.CommandLineOptions["CharacterSet"] = FileGeneratorUtilities.RemoveLineTag;
+
+                context.Options["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag;
+                context.CommandLineOptions["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag;
             }
             else
             {
@@ -220,6 +223,29 @@ namespace Sharpmake.Generators.VisualStudio
                 Options.Option(Options.Vc.General.CharacterSet.Default, () => { context.Options["CharacterSet"] = "NotSet"; context.CommandLineOptions["CharacterSet"] = FileGeneratorUtilities.RemoveLineTag; }),
                 Options.Option(Options.Vc.General.CharacterSet.Unicode, () => { context.Options["CharacterSet"] = "Unicode"; context.CommandLineOptions["CharacterSet"] = @"/D""_UNICODE"" /D""UNICODE"""; }),
                 Options.Option(Options.Vc.General.CharacterSet.MultiByte, () => { context.Options["CharacterSet"] = "MultiByte"; context.CommandLineOptions["CharacterSet"] = @"/D""_MBCS"""; })
+                );
+
+                //Options.Vc.Compiler.CppLanguageStandard.
+                //    CPP98                                   LanguageStandard=""
+                //    CPP11                                   LanguageStandard=""
+                //    CPP14                                   LanguageStandard="stdcpp14"                                    /std:c++14
+                //    CPP17                                   LanguageStandard="stdcpp17"                                    /std:c++17
+                //    GNU98                                   LanguageStandard=""
+                //    GNU11                                   LanguageStandard=""
+                //    GNU14                                   LanguageStandard="stdcpp14"                                    /std:c++14
+                //    GNU17                                   LanguageStandard="stdcpp17"                                    /std:c++17
+                //    Latest                                  LanguageStandard="stdcpplatest"                                /std:c++latest
+                context.SelectOption
+                (
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP98, () => { context.Options["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; context.CommandLineOptions["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP11, () => { context.Options["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; context.CommandLineOptions["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP14, () => { context.Options["LanguageStandard"] = "stdcpp14"; context.CommandLineOptions["LanguageStandard"] = "/std:c++14"; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.CPP17, () => { context.Options["LanguageStandard"] = "stdcpp17"; context.CommandLineOptions["LanguageStandard"] = "/std:c++17"; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU98, () => { context.Options["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; context.CommandLineOptions["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU11, () => { context.Options["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; context.CommandLineOptions["LanguageStandard"] = FileGeneratorUtilities.RemoveLineTag; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU14, () => { context.Options["LanguageStandard"] = "stdcpp14"; context.CommandLineOptions["LanguageStandard"] = "/std:c++14"; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.GNU17, () => { context.Options["LanguageStandard"] = "stdcpp17"; context.CommandLineOptions["LanguageStandard"] = "/std:c++17"; }),
+                Options.Option(Options.Vc.Compiler.CppLanguageStandard.Latest, () => { context.Options["LanguageStandard"] = "stdcpplatest"; context.CommandLineOptions["LanguageStandard"] = "/std:c++latest"; })
                 );
             }
 

--- a/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
+++ b/Sharpmake.Platforms/Sharpmake.CommonPlatforms/BasePlatform.Vcxproj.Template.cs
@@ -58,6 +58,7 @@ namespace Sharpmake
       <ForceConformanceInForLoopScope>[options.ForceConformanceInForLoopScope]</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>[options.RuntimeTypeInfo]</RuntimeTypeInfo>
       <OpenMPSupport>[options.OpenMP]</OpenMPSupport>
+      <LanguageStandard>[options.LanguageStandard]</LanguageStandard>
       <ExpandAttributedSource>false</ExpandAttributedSource>
       <AssemblerOutput>NoListing</AssemblerOutput>
       <GenerateXMLDocumentationFiles>[options.GenerateXMLDocumentation]</GenerateXMLDocumentationFiles>

--- a/Sharpmake/Options.Vc.cs
+++ b/Sharpmake/Options.Vc.cs
@@ -451,12 +451,17 @@ namespace Sharpmake
                     CPP98,
                     [Default]
                     CPP11,
+                    [DevEnvVersion(minimum = DevEnv.vs2015)]
                     CPP14,
+                    [DevEnvVersion(minimum = DevEnv.vs2017)]
                     CPP17,
                     GNU98,
                     GNU11,
+                    [DevEnvVersion(minimum = DevEnv.vs2015)]
                     GNU14,
+                    [DevEnvVersion(minimum = DevEnv.vs2017)]
                     GNU17,
+                    [DevEnvVersion(minimum = DevEnv.vs2015)]
                     Latest
                 }
             }

--- a/Sharpmake/Options.Vc.cs
+++ b/Sharpmake/Options.Vc.cs
@@ -452,9 +452,12 @@ namespace Sharpmake
                     [Default]
                     CPP11,
                     CPP14,
+                    CPP17,
                     GNU98,
                     GNU11,
-                    GNU14
+                    GNU14,
+                    GNU17,
+                    Latest
                 }
             }
 


### PR DESCRIPTION
Adds `CPP17, GNU17, Latest` to the `Options.Vc.Compiler.CppLanguageStandard` option and implements it for VS projects. C++98/11 are ignored as MSVC only provides options for C++14/17 and the working draft. The GNU C++ options are interpreted as the corresponding standard C++ options.

It might make sense to create a separate on/off option for the GNU extensions and get rid of the `GNU*` options in `CppLanguageStandard`.