### PR TITLE
Add support for Nuget in c++ and a few other goodies

### DIFF
--- a/Sharpmake.Generators/Generic/Makefile.cs
+++ b/Sharpmake.Generators/Generic/Makefile.cs
@@ -464,15 +464,19 @@ namespace Sharpmake.Generators.Generic
 
                 // CppLanguageStandard
                 SelectOption(conf,
-                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp17, () => { cxxflags.Append("-std=c++17 "); }),
-                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp14, () => { cxxflags.Append("-std=c++14 "); }),
-                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp11, () => { cxxflags.Append("-std=c++11 "); }),
-                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp98, () => { cxxflags.Append("-std=c++98 "); }),
-                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.GnuCpp11, () => { cxxflags.Append("-std=gnu++11 "); }),
-                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.GnuCpp98, () => { cxxflags.Append("-std=gnu++98 "); }),
-                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Default, () => { cxxflags.Append(""); })
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Default,   () => { cxxflags.Append(""); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp98,     () => { cxxflags.Append("-std=c++98 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp11,     () => { cxxflags.Append("-std=c++11 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp14,     () => { cxxflags.Append("-std=c++14 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp17,     () => { cxxflags.Append("-std=c++17 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.Cpp2a,     () => { cxxflags.Append("-std=c++2a "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.GnuCpp98,  () => { cxxflags.Append("-std=gnu++98 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.GnuCpp11,  () => { cxxflags.Append("-std=gnu++11 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.GnuCpp14,  () => { cxxflags.Append("-std=gnu++14 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.GnuCpp17,  () => { cxxflags.Append("-std=gnu++17 "); }),
+                    Options.Option(Options.Makefile.Compiler.CppLanguageStandard.GnuCpp2a,  () => { cxxflags.Append("-std=gnu++2a "); })
                     );
-
+                    
                 // Exceptions
                 SelectOption(conf,
                     Options.Option(Options.Makefile.Compiler.Exceptions.Enable, () => { cxxflags.Append("-fexceptions "); }),

--- a/Sharpmake.Generators/Generic/Makefile.cs
+++ b/Sharpmake.Generators/Generic/Makefile.cs
@@ -389,10 +389,15 @@ namespace Sharpmake.Generators.Generic
             string outputDirectory = PathMakeUnix(GetOutputDirectory(conf, projectFileInfo));
             options["OutputDirectory"] = outputDirectory;
 
-            #region Compiler
+			#region Compiler
 
-            // Defines
-            Strings defines = new Strings();
+			// Defines
+			if (conf.DefaultOption == Options.DefaultTarget.Debug)
+				conf.Defines.Add("_DEBUG");
+			else // Release
+				conf.Defines.Add("NDEBUG");
+
+			Strings defines = new Strings();
             defines.AddRange(conf.Defines);
             defines.InsertPrefix("-D");
             options["Defines"] = defines.JoinStrings(" ");

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -1064,7 +1064,7 @@ namespace Sharpmake.Generators.VisualStudio
                 Write(Template.MSBuild14PropertyGroup, writer, resolver);
             }
 
-            WriteCustomProperties(project, writer, resolver);
+            WriteCustomProperties(project.CustomProperties, writer, resolver);
 
             if (project.ProjectTypeGuids == CSharpProjectType.Wcf)
             {
@@ -1273,6 +1273,8 @@ namespace Sharpmake.Generators.VisualStudio
                 }
             }
 
+            WriteCustomProperties(project.CustomPropertiesPostImport, writer, resolver);
+
             foreach (var element in project.UsingTasks)
             {
                 using (resolver.NewScopedParameter("project", project))
@@ -1328,15 +1330,15 @@ namespace Sharpmake.Generators.VisualStudio
             writer.Close();
         }
 
-        private static void WriteCustomProperties(Project project, StreamWriter writer, Resolver resolver)
+        private static void WriteCustomProperties(Dictionary<string, string> properties, StreamWriter writer, Resolver resolver)
         {
-            if (project.CustomProperties.Any())
+            if (properties.Any())
             {
                 Write(Template.CustomPropertiesStart, writer, resolver);
-                foreach (var key in project.CustomProperties.Keys)
+                foreach (var key in properties.Keys)
                 {
                     resolver.SetParameter("custompropertyname", key);
-                    resolver.SetParameter("custompropertyvalue", project.CustomProperties[key]);
+                    resolver.SetParameter("custompropertyvalue", properties[key]);
                     Write(Template.CustomProperty, writer, resolver);
                 }
                 Write(Template.CustomPropertiesEnd, writer, resolver);

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -1343,13 +1343,6 @@ namespace Sharpmake.Generators.VisualStudio
             }
         }
 
-        internal enum CopyToOutputDirectory
-        {
-            Never,
-            Always,
-            PreserveNewest
-        }
-
         private void GenerateFiles(
             CSharpProject project,
             List<Project.Configuration> configurations,
@@ -1362,7 +1355,7 @@ namespace Sharpmake.Generators.VisualStudio
             foreach (var file in project.ResolvedContentFullFileNames)
             {
                 string include = Util.PathGetRelative(_projectPathCapitalized, file);
-                itemGroups.Contents.Add(new ItemGroups.Content { Include = include, LinkFolder = project.GetLinkFolder(include) });
+                itemGroups.Contents.Add(new ItemGroups.Content { Include = include, CopyToOutputDirectory = project.DefaultContentCopyOperation, LinkFolder = project.GetLinkFolder(include) });
             }
 
 

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -1449,7 +1449,7 @@ namespace Sharpmake.Generators.VisualStudio
 
             HashSet<string> allContents = new HashSet<string>(itemGroups.Contents.Select(c => c.Include));
             List<string> resolvedSources = project.ResolvedSourceFiles.Select(source => Util.PathGetRelative(_projectPathCapitalized, Project.GetCapitalizedFile(source))).ToList();
-            List<string> resolvedResources = project.ResourceFiles.Concat(project.ResolvedResourcesFullFileNames).Select(resource => Util.PathGetRelative(_projectPathCapitalized, Project.GetCapitalizedFile(resource))).Distinct().ToList();
+            List<string> resolvedResources = project.ResourceFiles.Concat(project.NonEmbeddedResourceFiles).Concat(project.ResolvedResourcesFullFileNames).Select(resource => Util.PathGetRelative(_projectPathCapitalized, Project.GetCapitalizedFile(resource))).Distinct().ToList();
             List<string> resolvedEmbeddedResource = project.ResourceFiles.Concat(project.AdditionalEmbeddedResource).Concat(project.AdditionalEmbeddedAssemblies).Select(f => Util.PathGetRelative(_projectPathCapitalized, Project.GetCapitalizedFile(f))).Distinct().ToList();
             List<string> resolvedNoneFiles =
                 (project.NoneFiles.Select(file => Util.PathGetRelative(_projectPathCapitalized, Project.GetCapitalizedFile(file))))

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -1873,7 +1873,7 @@ namespace Sharpmake.Generators.VisualStudio
                 bool runtimeTemplate = project.AdditionalRuntimeTemplates.Contains(ttFile);
                 string expectedExtension =
                     runtimeTemplate ? ".cs" :
-                    Util.GetTextTemplateDirectiveParam(Path.Combine(_projectPath, ttFile), "output", "extension") ?? ".cs";
+                    Util.GetTextTemplateOutputExtension(Path.Combine(_projectPath, ttFile)) ?? ".cs";
                 if (!expectedExtension.StartsWith(".", StringComparison.Ordinal))
                     expectedExtension = "." + expectedExtension;
                 string fileNameWithoutExtension = ttFile.Substring(0, ttFile.Length - TTExtension.Length);

--- a/Sharpmake.Generators/VisualStudio/Csproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Csproj.cs
@@ -2007,6 +2007,17 @@ namespace Sharpmake.Generators.VisualStudio
                     }));
 
                 referencesByPath.AddRange(
+                    conf.InteropReferencesByPath.Select(Util.GetCapitalizedPath)
+                    .Select(str => new ItemGroups.Reference
+                    {
+                        Include = Path.GetFileNameWithoutExtension(str),
+                        SpecificVersion = false,
+                        HintPath = Util.PathGetRelative(_projectPathCapitalized, str),
+                        Private = project.DependenciesCopyLocal.HasFlag(Project.DependenciesCopyLocalTypes.ExternalReferences),
+                        EmbedInteropTypes = true,
+                    }));
+
+                referencesByPath.AddRange(
                     project.AdditionalEmbeddedAssemblies.Select(Util.GetCapitalizedPath)
                     .Select(str => new ItemGroups.Reference
                     {

--- a/Sharpmake.Generators/VisualStudio/PackagesConfig.cs
+++ b/Sharpmake.Generators/VisualStudio/PackagesConfig.cs
@@ -32,14 +32,27 @@ namespace Sharpmake.Generators.VisualStudio
 
         public bool IsGenerated { get; internal set; } = false;
         public string PackagesConfigPath => Path.Combine(_projectPath, "packages.config");
-        public void Generate(Builder builder, CSharpProject project, List<Project.Configuration> configurations, string projectPath, List<string> generatedFiles, List<string> skipFiles)
+
+        public void Generate(Builder builder, CSharpProject project, List<Project.Configuration> configurations, string projectPath, IList<string> generatedFiles, IList<string> skipFiles)
+        {
+            var configuration = configurations[0];
+            var frameworkFlags = project.Targets.TargetPossibilities.Select(f => f.GetFragment<DotNetFramework>()).Aggregate((x, y) => x | y);
+            var frameworks = ((DotNetFramework[])Enum.GetValues(typeof(DotNetFramework))).Where(f => frameworkFlags.HasFlag(f)).Select(f => f.ToFolderName());
+
+            Generate(builder, configuration, frameworks, projectPath, generatedFiles, skipFiles);
+        }
+
+        public void Generate(Builder builder, Project.Configuration configuration, string framework, string projectPath, IList<string> generatedFiles, IList<string> skipFiles)
+        {
+            Generate(builder, configuration, new[] { framework }, projectPath, generatedFiles, skipFiles);
+        }
+
+        public void Generate(Builder builder, Project.Configuration configuration, IEnumerable<string> frameworks, string projectPath, IList<string> generatedFiles, IList<string> skipFiles)
         {
             _builder = builder;
             _projectPath = projectPath;
 
-            var configuration = configurations[0];
-            var frameworkFlags = project.Targets.TargetPossibilities.Select(f => f.GetFragment<DotNetFramework>()).Aggregate((x, y) => x | y);
-            GeneratePackagesConfig(configuration, frameworkFlags, generatedFiles, skipFiles);
+            GeneratePackagesConfig(configuration, frameworks, generatedFiles, skipFiles);
 
             _builder = null;
         }
@@ -55,7 +68,7 @@ namespace Sharpmake.Generators.VisualStudio
             return false;
         }
 
-        private void GeneratePackagesConfig(Project.Configuration conf, DotNetFramework frameworks, List<string> generatedFiles, List<string> skipFiles)
+        private void GeneratePackagesConfig(Project.Configuration conf, IEnumerable<string> frameworks, IList<string> generatedFiles, IList<string> skipFiles)
         {
             var packagesConfigPath = PackagesConfigPath;
 
@@ -83,12 +96,16 @@ namespace Sharpmake.Generators.VisualStudio
                     fileGenerator.Write(Template.Begin);
 
                     // dependencies
-                    DotNetFramework dnfs = ((DotNetFramework[])Enum.GetValues(typeof(DotNetFramework))).First(f => frameworks.HasFlag(f));
                     for (int i = 0; i < conf.ReferencesByNuGetPackage.SortedValues.Count; ++i)
                     {
                         using (fileGenerator.Declare("dependency", conf.ReferencesByNuGetPackage.SortedValues[i]))
-                        using (fileGenerator.Declare("framework", dnfs.ToFolderName()))
-                            fileGenerator.Write(Template.DependenciesItem);
+                        {
+                            foreach (var framework in frameworks)
+                            {
+                                using (fileGenerator.Declare("framework", framework))
+                                    fileGenerator.Write(Template.DependenciesItem);
+                            }
+                        }
                     }
 
                     fileGenerator.Write(Template.End);

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -446,6 +446,15 @@ namespace Sharpmake.Generators.VisualStudio
 ";
                 }
             }
+
+            public static class TargetElement
+            {
+                public static string CustomTarget =
+@"  <Target Name=""[targetElement.Name]"" [targetElement.TargetParameters]>
+    [targetElement.CustomTasks]
+  </Target>
+";
+            }
         }
     }
 }

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.Template.cs
@@ -144,8 +144,24 @@ namespace Sharpmake.Generators.VisualStudio
 @"    <Import Project=""[importedTargetsFile]"" Condition=""'$(Configuration)|$(Platform)'=='[conf.Name]|[platformName]'"" />
 ";
 
+                public static string ProjectTargetsNugetReferenceImport =
+@"    <Import Project=""$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets"" Condition=""Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" />
+";
+
+                public static string ProjectTargetsNugetReferenceError =
+@"    <Error Condition=""!Exists('$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets')"" Text=""$([[System.String]]::Format('$(ErrorText)', '$(SolutionDir)\packages\[packageName].[packageVersion]\build\native\[packageName].targets'))"" />
+";
+
                 public static string ProjectTargetsEnd =
 @"  </ImportGroup>
+";
+
+                public static string ProjectCustomTargetsBegin =
+@"  <Target Name=""name"" BeforeTargets=""PrepareForBuild"">
+";
+
+                public static string ProjectCustomTargetsEnd =
+@"  </Target>
 ";
 
                 public static string ProjectConfigurationsResourceCompile =

--- a/Sharpmake.Generators/VisualStudio/Vcxproj.cs
+++ b/Sharpmake.Generators/VisualStudio/Vcxproj.cs
@@ -759,6 +759,15 @@ namespace Sharpmake.Generators.VisualStudio
             }
             fileGenerator.Write(Template.Project.ProjectTargetsEnd);
 
+            foreach (var element in context.Project.CustomTargets)
+            {
+                using (fileGenerator.Declare("project", context.Project))
+                using (fileGenerator.Declare("targetElement", element))
+                {
+                    fileGenerator.Write(Template.TargetElement.CustomTarget);
+                }
+            }
+
             // add error checks for nuget package targets files
             if (firstConf.ReferencesByNuGetPackage.Count > 0)
             {

--- a/Sharpmake/DebugProjectGenerator.cs
+++ b/Sharpmake/DebugProjectGenerator.cs
@@ -278,6 +278,7 @@ namespace Sharpmake
             // ensure that no file will be automagically added
             SourceFilesExtensions.Clear();
             ResourceFilesExtensions.Clear();
+            NonEmbeddedResourceFilesExtensions.Clear();
             PRIFilesExtensions.Clear();
             ResourceFiles.Clear();
             NoneExtensions.Clear();

--- a/Sharpmake/Options.Makefile.cs
+++ b/Sharpmake/Options.Makefile.cs
@@ -37,8 +37,12 @@ namespace Sharpmake
                     Cpp11,
                     Cpp14,
                     Cpp17,
+                    Cpp2a,
                     GnuCpp98,
-                    GnuCpp11
+                    GnuCpp11,
+                    GnuCpp14,
+                    GnuCpp17,
+                    GnuCpp2a,
                 }
 
                 public enum Exceptions

--- a/Sharpmake/PackageReferences.cs
+++ b/Sharpmake/PackageReferences.cs
@@ -67,6 +67,15 @@ namespace Sharpmake
                 }
             }
 
+            public string Resolve(Resolver resolver, string customTemplate)
+            {
+                using (resolver.NewScopedParameter("packageName", Name))
+                using (resolver.NewScopedParameter("packageVersion", Version))
+                {
+                    return resolver.Resolve($"{customTemplate} />\n");
+                }
+            }
+
             public int CompareTo(PackageReference other)
             {
                 if (ReferenceEquals(this, other)) return 0;

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -1560,7 +1560,7 @@ namespace Sharpmake
             public Strings CustomPropsFiles = new Strings();  // vs2010+ .props files
             public Strings CustomTargetsFiles = new Strings();  // vs2010+ .targets files
 
-            // NuGet packages (only C# for now)
+            // NuGet packages (C# and visual studio c++ for now)
             public PackageReferences ReferencesByNuGetPackage = new PackageReferences();
 
             public bool? ReferenceOutputAssembly = null;

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -1550,6 +1550,7 @@ namespace Sharpmake
             public DotNetReferenceCollection DotNetReferences = new DotNetReferenceCollection();
 
             public Strings ProjectReferencesByPath = new Strings();
+            public Strings InteropReferencesByPath = new Strings();
             public Strings ReferencesByName = new Strings();
             public Strings ReferencesByNameExternal = new Strings();
             public Strings ReferencesByPath = new Strings();

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -22,6 +22,14 @@ using System.Threading;
 namespace Sharpmake
 {
     [Resolver.Resolvable]
+    public class CustomTargetElement
+    {
+        public string Name = "";
+        public string TargetParameters = "";
+        public string CustomTasks = "";
+    }
+
+    [Resolver.Resolvable]
     public partial class Project : Configurable<Project.Configuration>
     {
         private string _name = "[project.ClassName]";                                     // Project Name
@@ -156,6 +164,7 @@ namespace Sharpmake
 
         public Strings CustomPropsFiles = new Strings();  // vs2010+ .props files
         public Strings CustomTargetsFiles = new Strings();  // vs2010+ .targets files
+        public List<CustomTargetElement> CustomTargets = new List<CustomTargetElement>();
 
         public Strings LibraryPathsExcludeFromWarningRegex = new Strings();                 // Library paths where we want to ignore the path doesn't exist warning
         public Strings IncludePathsExcludeFromWarningRegex = new Strings();                 // Include paths where we want to ignore the path doesn't exist warning
@@ -1909,7 +1918,7 @@ namespace Sharpmake
 
             aspNetProject.NoneExtensions.Add(".pubxml");
 
-            aspNetProject.CustomTargets.Add(new CSharpProject.CustomTargetElement()
+            aspNetProject.CustomTargets.Add(new CustomTargetElement()
             {
                 Name = "MvcBuildViews",
                 TargetParameters = @"AfterTargets=""AfterBuild"" Condition=""'$(MvcBuildViews)' == 'true'""",
@@ -2049,7 +2058,6 @@ namespace Sharpmake
         public List<WebReferenceUrl> WebReferenceUrls = new List<WebReferenceUrl>();
         public List<ComReference> ComReferences = new List<ComReference>();
         public UniqueList<ImportProject> ImportProjects = new UniqueList<ImportProject>();
-        public List<CustomTargetElement> CustomTargets = new List<CustomTargetElement>();
         public List<UsingTask> UsingTasks = new List<UsingTask>();
 
         public bool? WcfAutoStart; // Wcf Auto-Start service when debugging
@@ -2064,24 +2072,6 @@ namespace Sharpmake
         public Options.CSharp.RunPostBuildEvent RunPostBuildEvent = Options.CSharp.RunPostBuildEvent.OnBuildSuccess;
 
         public string CodeAnalysisRuleSetFileName;
-
-        [Resolver.Resolvable]
-        public class CustomTargetElement
-        {
-            public string Name;
-            public string TargetParameters;
-            public string CustomTasks;
-
-            public CustomTargetElement()
-            { }
-
-            public CustomTargetElement(string name, string targetParameters, string customTasks)
-            {
-                Name = name;
-                TargetParameters = targetParameters;
-                CustomTasks = customTasks;
-            }
-        }
 
         [Resolver.Resolvable]
         public class UsingTask

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -1850,6 +1850,13 @@ namespace Sharpmake
         public FileType FileType = FileType.File;
     }
 
+    public enum CopyToOutputDirectory
+    {
+        Never,
+        Always,
+        PreserveNewest
+    }
+
     public enum CSharpProjectType
     {
         Test,
@@ -2019,6 +2026,7 @@ namespace Sharpmake
     public class CSharpProject : Project
     {
         public Strings ContentExtension = new Strings();
+        public CopyToOutputDirectory? DefaultContentCopyOperation = null;
         public Strings VsctExtension = new Strings(".vsct");
         public CSharpProjectType ProjectTypeGuids = CSharpProjectType.Default;
         public string ResourcesPath = null;

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -175,6 +175,7 @@ namespace Sharpmake
         public Dictionary<string, string> ExtensionBuildTools = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);  // extension -> tool name
 
         public Dictionary<string, string> CustomProperties = new Dictionary<string, string>();      // custom properties are added to the project xml as <Key>Value</Key>
+        public Dictionary<string, string> CustomPropertiesPostImport = new Dictionary<string, string>();  // additional custom properties that are added after imports
 
         public Dictionary<string, string> CustomFilterMapping = new Dictionary<string, string>();  /// maps relative source directory to a custom filter path for vcxproj.filter files
 

--- a/Sharpmake/Project.cs
+++ b/Sharpmake/Project.cs
@@ -147,6 +147,9 @@ namespace Sharpmake
         public Strings ResourceFiles = new Strings();
         public Strings ResourceFilesExtensions = new Strings();
 
+        public Strings NonEmbeddedResourceFiles = new Strings();
+        public Strings NonEmbeddedResourceFilesExtensions = new Strings();
+
         public Strings NatvisFiles = new Strings();
         public Strings NatvisFilesExtensions = new Strings(".natvis");
 
@@ -715,7 +718,7 @@ namespace Sharpmake
             }
 
             // Only scan directory for files if needed
-            if (SourceFilesExtensions.Count != 0 || ResourceFilesExtensions.Count != 0 || PRIFilesExtensions.Count != 0 || NoneExtensions.Count != 0 || NoneExtensionsCopyIfNewer.Count != 0)
+            if (SourceFilesExtensions.Count != 0 || ResourceFilesExtensions.Count != 0 || NonEmbeddedResourceFilesExtensions.Count != 0 || PRIFilesExtensions.Count != 0 || NoneExtensions.Count != 0 || NoneExtensionsCopyIfNewer.Count != 0)
             {
                 string capitalizedSourceRootPath = Util.GetCapitalizedPath(SourceRootPath);
 
@@ -747,6 +750,7 @@ namespace Sharpmake
 
                     AddMatchExtensionFiles(additionalFiles, ref PRIFiles, PRIFilesExtensions);
                     AddMatchExtensionFiles(additionalFiles, ref ResourceFiles, ResourceFilesExtensions);
+                    AddMatchExtensionFiles(additionalFiles, ref NonEmbeddedResourceFiles, NonEmbeddedResourceFilesExtensions);
                     AddMatchExtensionFiles(additionalFiles, ref NatvisFiles, NatvisFilesExtensions);
                     AddMatchExtensionFiles(additionalFiles, ref NoneFiles, NoneExtensions);
                     AddMatchExtensionFiles(additionalFiles, ref NoneFilesCopyIfNewer, NoneExtensionsCopyIfNewer);
@@ -774,6 +778,9 @@ namespace Sharpmake
 
                 AddMatchExtensionFiles(files, ref ResourceFiles, ResourceFilesExtensions);
                 Util.ResolvePath(SourceRootPath, ref ResourceFiles);
+
+                AddMatchExtensionFiles(files, ref NonEmbeddedResourceFiles, NonEmbeddedResourceFilesExtensions);
+                Util.ResolvePath(SourceRootPath, ref NonEmbeddedResourceFiles);
 
                 AddMatchExtensionFiles(files, ref NatvisFiles, NatvisFilesExtensions);
                 Util.ResolvePath(SourceRootPath, ref NatvisFiles);
@@ -1747,6 +1754,7 @@ namespace Sharpmake
             // Disable automatic source files discovery
             SourceFilesExtensions.Clear();
             ResourceFilesExtensions.Clear();
+            NonEmbeddedResourceFilesExtensions.Clear();
             PRIFilesExtensions.Clear();
         }
     }
@@ -1914,6 +1922,7 @@ namespace Sharpmake
             aspNetProject.ContentExtension.Add(contentExtension);
 
             aspNetProject.ResourceFilesExtensions.Remove(contentExtension);
+            aspNetProject.NonEmbeddedResourceFilesExtensions.Remove(contentExtension);
             aspNetProject.EmbeddedResourceExtensions.Remove(contentExtension);
 
             aspNetProject.NoneExtensions.Add(".pubxml");

--- a/Sharpmake/Solution.Configuration.cs
+++ b/Sharpmake/Solution.Configuration.cs
@@ -206,6 +206,11 @@ namespace Sharpmake
                 return null;
             }
 
+            public IncludedProjectInfo GetProject<TPROJECTTYPE>()
+            {
+                return GetProject(typeof(TPROJECTTYPE));
+            }
+            
             private void AddProjectInternal(Type projectType, ITarget projectTarget, bool inactiveProject, string solutionFolder, string callerInfo)
             {
                 IncludedProjectInfo includedProjectInfo = GetProject(projectType);

--- a/Sharpmake/Util.cs
+++ b/Sharpmake/Util.cs
@@ -78,6 +78,21 @@ namespace Sharpmake
             return PathMakeStandard(path, !Util.IsRunningInMono());
         }
 
+        private static string GetTextTemplateDirectiveParam(string[] templateText, string directive, string paramName)
+        {
+            Regex regex = new Regex(@"<#@\s*?" + directive + @"\s+?.*?" + paramName + @"=""(?<paramValue>.*?)"".*?#>");
+
+            foreach (var line in templateText)
+            {
+                Match m = regex.Match(line);
+                Group g = m.Groups["paramValue"];
+                if (g != null && g.Success)
+                    return g.Value;
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Finds the first occurence of directive and returns the 
         /// requested param value. Ex:
@@ -88,9 +103,28 @@ namespace Sharpmake
         /// </summary>
         public static string GetTextTemplateDirectiveParam(string filePath, string directive, string paramName)
         {
+            return GetTextTemplateDirectiveParam(File.ReadAllLines(filePath), directive, paramName);
+        }
+
+        /// <summary>
+        /// Finds the output type of a template, looking for both the directive form and the Host.SetFileExtension form
+        /// will match:
+        ///  <#@ output extension=".txt" #>
+        /// or
+        ///  Host.SetFileExtension(".txt")
+        /// and return ".txt"
+        /// </summary>
+		public static string GetTextTemplateOutputExtension(string filePath)
+        {
             string[] templateText = File.ReadAllLines(filePath);
 
-            Regex regex = new Regex(@"<#@\s*?" + directive + @"\s+?.*?" + paramName + @"=""(?<paramValue>.*?)"".*?#>");
+            var output = Util.GetTextTemplateDirectiveParam(templateText, "output", "extension");
+            if (output != null)
+                return output;
+
+            // alternatively look for host.SetFileExtension
+
+            Regex regex = new Regex(@"Host.SetFileExtension\(""(?<paramValue>.*?)""\)");
 
             foreach (var line in templateText)
             {

--- a/bootstrap-sharpmake.bat
+++ b/bootstrap-sharpmake.bat
@@ -6,12 +6,19 @@ pushd "%~dp0"
 
 set SHARPMAKE_EXECUTABLE=bin\debug\Sharpmake.Application.exe
 
-if not defined VS140COMNTOOLS (
-    echo ERROR: Cannot determine the location of the VS Common Tools folder.
-    goto error
+if defined VS140COMNTOOLS (
+    call "%VS140COMNTOOLS%VsMSBuildCmd.bat"
+    goto buildcmdcalled
+)
+if defined VS150COMNTOOLS (
+    call "%VS150COMNTOOLS%VsMSBuildCmd.bat"
+    goto buildcmdcalled
 )
 
-call "%VS140COMNTOOLS%VsMSBuildCmd.bat"
+echo ERROR: Cannot determine the location of the VS Common Tools folder.
+goto error
+
+:buildcmdcalled
 if %errorlevel% NEQ 0 goto error
 
 call :NugetRestore Sharpmake/Sharpmake.csproj

--- a/regression_test.py
+++ b/regression_test.py
@@ -97,6 +97,11 @@ def red_bg():
 def green_bg():
     if os.name == "nt":
         os.system("color 2F")
+        
+def black_bg():
+    if os.name == "nt":
+        os.system("color 0F")
+       
 
 def pause(timeout=None):
     if timeout is None:
@@ -157,5 +162,6 @@ def launch_tests():
     finally:
         os.chdir(entry_path)
 
+black_bg()
 exit_code = launch_tests()
 sys.exit(exit_code)

--- a/samples/PackageReferences/PackageReferences.sharpmake.cs
+++ b/samples/PackageReferences/PackageReferences.sharpmake.cs
@@ -1,7 +1,7 @@
 ﻿using Sharpmake;
 using System;
 
-namespace CSharpPackageReference
+namespace PackageReference
 {
     [Generate]
     public class PackageReferences : CSharpProject
@@ -9,7 +9,7 @@ namespace CSharpPackageReference
         public PackageReferences()
         {
             AddTargets(new Target(
-            Platform.anycpu,
+            Platform.win64,
             DevEnv.vs2015 | DevEnv.vs2017,
             Optimization.Debug | Optimization.Release,
             OutputType.Dll,
@@ -40,12 +40,44 @@ namespace CSharpPackageReference
     }
 
     [Generate]
+    public class PackageReferencesCPP : Project
+    {
+        public PackageReferencesCPP()
+        {
+            AddTargets(new Target(
+            Platform.win64,
+            DevEnv.vs2015 | DevEnv.vs2017,
+            Optimization.Debug | Optimization.Release,
+            OutputType.Dll,
+            Blob.NoBlob,
+            BuildSystem.MSBuild,
+            DotNetFramework.v4_5 | DotNetFramework.v4_6_2));
+
+            RootPath = @"[project.SharpmakeCsPath]\projects\[project.Name]";
+
+            // This Path will be used to get all SourceFiles in this Folder and all subFolders
+            SourceRootPath = @"[project.SharpmakeCsPath]\codebase\[project.Name]";
+        }
+
+        [Configure()]
+        public virtual void ConfigureAll(Configuration conf, Target target)
+        {
+            conf.ProjectFileName = "[project.Name].[target.DevEnv].[target.Framework]";
+            conf.ProjectPath = @"[project.RootPath]";
+
+            conf.Options.Add(Options.CSharp.TreatWarningsAsErrors.Enabled);
+
+            conf.ReferencesByNuGetPackage.Add("gtest-vc140-static-64", "1.1.0");
+        }
+    }
+
+    [Generate]
     public class PackageReferenceSolution : CSharpSolution
     {
         public PackageReferenceSolution()
         {
             AddTargets(new Target(
-            Platform.anycpu,
+            Platform.win64,
             DevEnv.vs2015 | DevEnv.vs2017,
             Optimization.Debug | Optimization.Release,
             OutputType.Dll,
@@ -64,6 +96,7 @@ namespace CSharpPackageReference
             conf.SolutionPath = @"[solution.SharpmakeCsPath]\projects\";
 
             conf.AddProject<PackageReferences>(target);
+            conf.AddProject<PackageReferencesCPP>(target);
         }
 
         [Main]

--- a/samples/PackageReferences/codebase/PackageReferencesCPP/main.cpp
+++ b/samples/PackageReferences/codebase/PackageReferencesCPP/main.cpp
@@ -1,0 +1,6 @@
+#include "stdafx.h"
+
+int main(int, char**)
+{
+	return 0;
+}

--- a/samples/PackageReferences/codebase/PackageReferencesCPP/stdafx.cpp
+++ b/samples/PackageReferences/codebase/PackageReferencesCPP/stdafx.cpp
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/samples/PackageReferences/codebase/PackageReferencesCPP/stdafx.h
+++ b/samples/PackageReferences/codebase/PackageReferencesCPP/stdafx.h
@@ -1,0 +1,6 @@
+#if !defined(_STDAFX_H)
+#define _STDAFX_H
+
+#include <cstdio>
+
+#endif // _STDAFX_H

--- a/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2015.v4_5.sln
+++ b/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2015.v4_5.sln
@@ -2,16 +2,22 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageReferences", "packagereferences\PackageReferences.vs2015.v4_5.csproj", "{FF45B1FC-A77A-0607-80EF-9A177D621CBF}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PackageReferencesCPP", "packagereferencescpp\packagereferencescpp.vs2015.v4_5.vcxproj", "{C6FCD9B1-7DC4-58F5-BE1D-3EA1515108C1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Debug|x64.ActiveCfg = Debug|x64
+		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Debug|x64.Build.0 = Debug|x64
+		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Release|x64.ActiveCfg = Release|x64
+		{FF45B1FC-A77A-0607-80EF-9A177D621CBF}.Release|x64.Build.0 = Release|x64
+		{C6FCD9B1-7DC4-58F5-BE1D-3EA1515108C1}.Debug|x64.ActiveCfg = Debug|x64
+		{C6FCD9B1-7DC4-58F5-BE1D-3EA1515108C1}.Debug|x64.Build.0 = Debug|x64
+		{C6FCD9B1-7DC4-58F5-BE1D-3EA1515108C1}.Release|x64.ActiveCfg = Release|x64
+		{C6FCD9B1-7DC4-58F5-BE1D-3EA1515108C1}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2015.v4_6_2.sln
+++ b/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2015.v4_6_2.sln
@@ -2,16 +2,22 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageReferences", "packagereferences\PackageReferences.vs2015.v4_6_2.csproj", "{12F3BEF1-9767-C43D-7340-3A478212E3C6}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PackageReferencesCPP", "packagereferencescpp\packagereferencescpp.vs2015.v4_6_2.vcxproj", "{FFA325D4-2ADF-8C5F-0239-56D65140A797}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Debug|x64.ActiveCfg = Debug|x64
+		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Debug|x64.Build.0 = Debug|x64
+		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Release|x64.ActiveCfg = Release|x64
+		{12F3BEF1-9767-C43D-7340-3A478212E3C6}.Release|x64.Build.0 = Release|x64
+		{FFA325D4-2ADF-8C5F-0239-56D65140A797}.Debug|x64.ActiveCfg = Debug|x64
+		{FFA325D4-2ADF-8C5F-0239-56D65140A797}.Debug|x64.Build.0 = Debug|x64
+		{FFA325D4-2ADF-8C5F-0239-56D65140A797}.Release|x64.ActiveCfg = Release|x64
+		{FFA325D4-2ADF-8C5F-0239-56D65140A797}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2017.v4_5.sln
+++ b/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2017.v4_5.sln
@@ -2,16 +2,22 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageReferences", "packagereferences\PackageReferences.vs2017.v4_5.csproj", "{483911DF-DC29-B6DC-614A-9527B1F112E8}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PackageReferencesCPP", "packagereferencescpp\packagereferencescpp.vs2017.v4_5.vcxproj", "{7401537A-F3B7-C386-70A2-94CB74940693}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Debug|x64.ActiveCfg = Debug|x64
+		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Debug|x64.Build.0 = Debug|x64
+		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Release|x64.ActiveCfg = Release|x64
+		{483911DF-DC29-B6DC-614A-9527B1F112E8}.Release|x64.Build.0 = Release|x64
+		{7401537A-F3B7-C386-70A2-94CB74940693}.Debug|x64.ActiveCfg = Debug|x64
+		{7401537A-F3B7-C386-70A2-94CB74940693}.Debug|x64.Build.0 = Debug|x64
+		{7401537A-F3B7-C386-70A2-94CB74940693}.Release|x64.ActiveCfg = Release|x64
+		{7401537A-F3B7-C386-70A2-94CB74940693}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2017.v4_6_2.sln
+++ b/samples/PackageReferences/reference/projects/PackageReferenceSolution.vs2017.v4_6_2.sln
@@ -2,16 +2,22 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageReferences", "packagereferences\PackageReferences.vs2017.v4_6_2.csproj", "{E164BF08-4260-CB60-419A-B10E0A8BC84F}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PackageReferencesCPP", "packagereferencescpp\packagereferencescpp.vs2017.v4_6_2.vcxproj", "{7DD9BA66-2982-D2EE-82E9-0569CC07F716}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Debug|x64.ActiveCfg = Debug|x64
+		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Debug|x64.Build.0 = Debug|x64
+		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Release|x64.ActiveCfg = Release|x64
+		{E164BF08-4260-CB60-419A-B10E0A8BC84F}.Release|x64.Build.0 = Release|x64
+		{7DD9BA66-2982-D2EE-82E9-0569CC07F716}.Debug|x64.ActiveCfg = Debug|x64
+		{7DD9BA66-2982-D2EE-82E9-0569CC07F716}.Debug|x64.Build.0 = Debug|x64
+		{7DD9BA66-2982-D2EE-82E9-0569CC07F716}.Release|x64.ActiveCfg = Release|x64
+		{7DD9BA66-2982-D2EE-82E9-0569CC07F716}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2015.v4_5.csproj
+++ b/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2015.v4_5.csproj
@@ -2,8 +2,8 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <PlatformTarget Condition=" '$(Platform)' == '' ">AnyCPU</PlatformTarget>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <PlatformTarget Condition=" '$(Platform)' == '' ">x64</PlatformTarget>
     <ProjectGuid>{FF45B1FC-A77A-0607-80EF-9A177D621CBF}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -12,26 +12,26 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>output\anycpu\debug</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\debug</IntermediateOutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <OutputPath>output\win64\debug</OutputPath>
+    <IntermediateOutputPath>obj\win64\debug</IntermediateOutputPath>
+    <DefineConstants>DEBUG;TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>output\anycpu\release</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\release</IntermediateOutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <OutputPath>output\win64\release</OutputPath>
+    <IntermediateOutputPath>obj\win64\release</IntermediateOutputPath>
+    <DefineConstants>TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>

--- a/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2015.v4_6_2.csproj
+++ b/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2015.v4_6_2.csproj
@@ -2,8 +2,8 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <PlatformTarget Condition=" '$(Platform)' == '' ">AnyCPU</PlatformTarget>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <PlatformTarget Condition=" '$(Platform)' == '' ">x64</PlatformTarget>
     <ProjectGuid>{12F3BEF1-9767-C43D-7340-3A478212E3C6}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -12,26 +12,26 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>output\anycpu\debug</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\debug</IntermediateOutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <OutputPath>output\win64\debug</OutputPath>
+    <IntermediateOutputPath>obj\win64\debug</IntermediateOutputPath>
+    <DefineConstants>DEBUG;TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>output\anycpu\release</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\release</IntermediateOutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <OutputPath>output\win64\release</OutputPath>
+    <IntermediateOutputPath>obj\win64\release</IntermediateOutputPath>
+    <DefineConstants>TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>

--- a/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2017.v4_5.csproj
+++ b/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2017.v4_5.csproj
@@ -3,8 +3,8 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <PlatformTarget Condition=" '$(Platform)' == '' ">AnyCPU</PlatformTarget>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <PlatformTarget Condition=" '$(Platform)' == '' ">x64</PlatformTarget>
     <ProjectGuid>{483911DF-DC29-B6DC-614A-9527B1F112E8}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -13,26 +13,26 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>output\anycpu\debug</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\debug</IntermediateOutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <OutputPath>output\win64\debug</OutputPath>
+    <IntermediateOutputPath>obj\win64\debug</IntermediateOutputPath>
+    <DefineConstants>DEBUG;TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>output\anycpu\release</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\release</IntermediateOutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <OutputPath>output\win64\release</OutputPath>
+    <IntermediateOutputPath>obj\win64\release</IntermediateOutputPath>
+    <DefineConstants>TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>

--- a/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2017.v4_6_2.csproj
+++ b/samples/PackageReferences/reference/projects/packagereferences/PackageReferences.vs2017.v4_6_2.csproj
@@ -3,8 +3,8 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <PlatformTarget Condition=" '$(Platform)' == '' ">AnyCPU</PlatformTarget>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <PlatformTarget Condition=" '$(Platform)' == '' ">x64</PlatformTarget>
     <ProjectGuid>{E164BF08-4260-CB60-419A-B10E0A8BC84F}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -13,26 +13,26 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>output\anycpu\debug</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\debug</IntermediateOutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <OutputPath>output\win64\debug</OutputPath>
+    <IntermediateOutputPath>obj\win64\debug</IntermediateOutputPath>
+    <DefineConstants>DEBUG;TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>output\anycpu\release</OutputPath>
-    <IntermediateOutputPath>obj\anycpu\release</IntermediateOutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <OutputPath>output\win64\release</OutputPath>
+    <IntermediateOutputPath>obj\win64\release</IntermediateOutputPath>
+    <DefineConstants>TRACE;WIN64</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_5.vcxproj
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_5.vcxproj
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C6FCD9B1-7DC4-58F5-BE1D-3EA1515108C1}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <RootNamespace>PackageReferencesCPP</RootNamespace>
+    <ProjectName>PackageReferencesCPP</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\debug\</OutDir>
+    <IntDir>obj\win64\debug\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\release\</OutDir>
+    <IntDir>obj\win64\release\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN64;_CONSOLE;_DEBUG;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\debug\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\debug\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>false</OptimizeReferences>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\debug\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;WIN64;_CONSOLE;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\release\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\release\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\release\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
+ />
+  </ImportGroup>
+  <Target Name="name" BeforeTargets="PrepareForBuild">
+  <PropertyGroup>
+    <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+  </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets'))" />
+ />
+  </Target>
+  <ItemGroup>
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_5.vcxproj.filters
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_5.vcxproj.filters
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_6_2.vcxproj
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_6_2.vcxproj
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FFA325D4-2ADF-8C5F-0239-56D65140A797}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <RootNamespace>PackageReferencesCPP</RootNamespace>
+    <ProjectName>PackageReferencesCPP</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\debug\</OutDir>
+    <IntDir>obj\win64\debug\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\release\</OutDir>
+    <IntDir>obj\win64\release\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN64;_CONSOLE;_DEBUG;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\debug\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\debug\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>false</OptimizeReferences>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\debug\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;WIN64;_CONSOLE;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\release\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\release\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\release\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
+ />
+  </ImportGroup>
+  <Target Name="name" BeforeTargets="PrepareForBuild">
+  <PropertyGroup>
+    <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+  </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets'))" />
+ />
+  </Target>
+  <ItemGroup>
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_6_2.vcxproj.filters
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2015.v4_6_2.vcxproj.filters
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_5.vcxproj
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_5.vcxproj
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7401537A-F3B7-C386-70A2-94CB74940693}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <RootNamespace>PackageReferencesCPP</RootNamespace>
+    <ProjectName>PackageReferencesCPP</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\debug\</OutDir>
+    <IntDir>obj\win64\debug\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\release\</OutDir>
+    <IntDir>obj\win64\release\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN64;_CONSOLE;_DEBUG;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\debug\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\debug\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>false</OptimizeReferences>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\debug\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;WIN64;_CONSOLE;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\release\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\release\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\release\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
+ />
+  </ImportGroup>
+  <Target Name="name" BeforeTargets="PrepareForBuild">
+  <PropertyGroup>
+    <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+  </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets'))" />
+ />
+  </Target>
+  <ItemGroup>
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_5.vcxproj.filters
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_5.vcxproj.filters
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_6_2.vcxproj
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_6_2.vcxproj
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7DD9BA66-2982-D2EE-82E9-0569CC07F716}</ProjectGuid>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <RootNamespace>PackageReferencesCPP</RootNamespace>
+    <ProjectName>PackageReferencesCPP</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\debug\</OutDir>
+    <IntDir>obj\win64\debug\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>packagereferencescpp</TargetName>
+    <OutDir>output\win64\release\</OutDir>
+    <IntDir>obj\win64\release\</IntDir>
+    <TargetExt>.exe</TargetExt>
+    <GenerateManifest>true</GenerateManifest>
+    <LinkIncremental>false</LinkIncremental>
+    <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+    <IgnoreImportLibrary>false</IgnoreImportLibrary>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN64;_CONSOLE;_DEBUG;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\debug\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\debug\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\debug\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>false</OptimizeReferences>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\debug\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <PreprocessorDefinitions>NDEBUG;WIN64;_CONSOLE;%(PreprocessorDefinitions);$(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>false</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <UndefineAllPreprocessorDefinitions>false</UndefineAllPreprocessorDefinitions>
+      <IgnoreStandardIncludePath>false</IgnoreStandardIncludePath>
+      <PreprocessToFile>false</PreprocessToFile>
+      <PreprocessSuppressLineNumbers>false</PreprocessSuppressLineNumbers>
+      <PreprocessKeepComments>false</PreprocessKeepComments>
+      <StringPooling>true</StringPooling>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ExceptionHandling>false</ExceptionHandling>
+      <SmallerTypeCheck>false</SmallerTypeCheck>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StructMemberAlignment>Default</StructMemberAlignment>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <CreateHotpatchableImage>false</CreateHotpatchableImage>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <OpenMPSupport>false</OpenMPSupport>
+      <ExpandAttributedSource>false</ExpandAttributedSource>
+      <AssemblerOutput>NoListing</AssemblerOutput>
+      <GenerateXMLDocumentationFiles>false</GenerateXMLDocumentationFiles>
+      <BrowseInformation>false</BrowseInformation>
+      <CallingConvention>Cdecl</CallingConvention>
+      <CompileAs>Default</CompileAs>
+      <ProgramDatabaseFileName>obj\win64\release\packagereferencescpp_compiler.pdb</ProgramDatabaseFileName>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OutputFile>output\win64\release\packagereferencescpp.exe</OutputFile>
+      <ShowProgress>NotSet</ShowProgress>
+      <ProgramDatabaseFile>output\win64\release\packagereferencescpp.pdb</ProgramDatabaseFile>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>false</MapExports>
+      <SwapRunFromCD>false</SwapRunFromCD>
+      <SwapRunFromNET>false</SwapRunFromNET>
+      <Driver>NotSet</Driver>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <ProfileGuidedDatabase>
+      </ProfileGuidedDatabase>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreEmbeddedIDL>false</IgnoreEmbeddedIDL>
+      <TypeLibraryResourceID>1</TypeLibraryResourceID>
+      <NoEntryPoint>false</NoEntryPoint>
+      <SetChecksum>false</SetChecksum>
+      <TurnOffAssemblyGeneration>false</TurnOffAssemblyGeneration>
+      <TargetMachine>MachineX64</TargetMachine>
+      <Profile>false</Profile>
+      <CLRImageType>Default</CLRImageType>
+      <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
+      <AdditionalOptions></AdditionalOptions>
+      <AdditionalDependencies>;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MapFileName>output\win64\release\packagereferencescpp.map</MapFileName>
+      <BaseAddress></BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets" Condition="Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" />
+ />
+  </ImportGroup>
+  <Target Name="name" BeforeTargets="PrepareForBuild">
+  <PropertyGroup>
+    <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+  </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\gtest-vc140-static-64.1.1.0\build\native\gtest-vc140-static-64.targets'))" />
+ />
+  </Target>
+  <ItemGroup>
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_6_2.vcxproj.filters
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packagereferencescpp.vs2017.v4_6_2.vcxproj.filters
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\main.cpp" />
+    <ClCompile Include="..\..\codebase\PackageReferencesCPP\stdafx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\codebase\PackageReferencesCPP\stdafx.h" />
+  </ItemGroup>
+</Project>

--- a/samples/PackageReferences/reference/projects/packagereferencescpp/packages.config
+++ b/samples/PackageReferences/reference/projects/packagereferencescpp/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="gtest-vc140-static-64" version="1.1.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
I had a few other issues using Visual Studio 2017 Community so here's a few fixes:
1. New form of nuget using references wasn't working out of the box so I also added an option to always use package.config form which also keeps consistency with c++ which only supports that method.
2. I didn't have the windowssdk version installed that's hardcoded so I added an option to simplify detecting and setting the highest installed version. I didn't use it by default since it will break unit tests depending on the users setup, but a user can just add KitsRootPaths.SetKitsRoot10ToHighestInstalledVersion(); to their SharpmakeMain.
