### PR TITLE
Project build dependency for solutions that don't have fastbuild projects

### DIFF
--- a/Sharpmake.Generators/VisualStudio/Sln.cs
+++ b/Sharpmake.Generators/VisualStudio/Sln.cs
@@ -364,6 +364,25 @@ namespace Sharpmake.Generators.VisualStudio
                                 fileGenerator.Write(Template.Solution.ProjectSectionEnd);
                             }
                         }
+                        else
+                        {
+                            bool writeProjectDependencies = resolvedProject.Configurations.Any(conf => conf.ProjectGuidDependencies.Count > 0);
+                            if (writeProjectDependencies)
+                            {
+                                fileGenerator.Write(Template.Solution.ProjectDependencyBegin);
+
+                                foreach (Project.Configuration configuration in resolvedProject.Configurations)
+                                {
+                                    foreach (string projectGuid in configuration.ProjectGuidDependencies)
+                                    {
+                                        using (fileGenerator.Declare("projectDependencyGuid", projectGuid))
+                                            fileGenerator.Write(Template.Solution.ProjectDependency);
+                                    }
+                                }
+
+                                fileGenerator.Write(Template.Solution.ProjectSectionEnd);
+                            }
+                        }
 
                         fileGenerator.Write(Template.Solution.ProjectEnd);
                     }

--- a/Sharpmake/Project.Configuration.cs
+++ b/Sharpmake/Project.Configuration.cs
@@ -30,6 +30,7 @@ namespace Sharpmake
         IncludePaths = 1 << 3,
         Defines = 1 << 4,
         AdditionalUsingDirectories = 1 << 5,
+        BuildPrerequisite = 1 << 6,
 
         // Useful masks
         Default = LibraryFiles
@@ -399,6 +400,11 @@ namespace Sharpmake
             /// Request sharpmake to dump the dependency graph of this configuration
             /// </summary>
             public bool DumpDependencyGraph = false;
+
+            /// <summary>
+            /// List of GUIDs of the projects that this project depends on to be properly built
+            /// </summary>
+            public Strings ProjectGuidDependencies = new Strings();
 
             public void AddSourceFileWithExceptionSetting(string filename, Options.Vc.Compiler.Exceptions exceptionSetting)
             {
@@ -1600,6 +1606,11 @@ namespace Sharpmake
                         _resolvedTargetDependsFiles.AddRange(dependency.TargetDependsFiles);
                         _resolvedExecDependsFiles.AddRange(dependency.EventPreBuildExe);
                         _resolvedExecDependsFiles.AddRange(dependency.EventPostBuildExe);
+                    }
+
+                    if (dependencySetting.HasFlag(DependencySetting.BuildPrerequisite))
+                    {
+                        ProjectGuidDependencies.Add(dependency.ProjectGuid);
                     }
 
                     bool isExport = dependency.Project.GetType().IsDefined(typeof(Export), false);


### PR DESCRIPTION
Project build dependency for solutions that don't have fastbuild projects

* Added a way to add a project build dependency in Visual Studio's solution files.
* The new DependencySetting.BuildPrerequisite gathers a list of project's GUIDs, which is how Visual Studio resolves build dependencies.
* The list of GUIDs is then applied in the VisualStudio's Sln generator only if the solution is not a fast build one, to preserve current behavior intact.

I wasn't too sure whether or not to add new Project.Configuration.AddBuildDependency method or to simply add a flag to DependencySetting. In the end I chose the later as I felt that it was easier for existing Sharpmake scripts to simple update their calls to AddPublicDependency/AddPrivateDependency with the additional flag.

Moreover, going through AddPublicDependency/AddPrivateDependency, circular dependencies are already found and throws an exception, so it's not possible to generate a solution that contains projects that requires themselves to be built first.

Tests: ran unit tests + tested with a Sharpmake script that generates a bunch of projects that need such build dependencies. Verified that the output solution in Vs2015 & Vs2017 contains the proper dependencies.