### PR TITLE
Fix bootstrap-sharpmake.bat so that it works with Visual Studio versi…

### DIFF
--- a/bootstrap-sharpmake.bat
+++ b/bootstrap-sharpmake.bat
@@ -7,7 +7,7 @@ pushd "%~dp0"
 set SHARPMAKE_EXECUTABLE=bin\debug\Sharpmake.Application.exe
 
 :: Try to use vswhere to find the latest Visual Studio installation
-set VSWHERE_PATH=C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe
+set VSWHERE_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
 if exist %VSWHERE_PATH% (
     for /f "usebackq tokens=1* delims=: " %%i in (`"%VSWHERE_PATH%" -latest -requires Microsoft.VisualStudio.Workload.NativeDesktop`) do (
          if /i "%%i"=="installationPath" set VSINSTALLATION=%%j


### PR DESCRIPTION
…ons newer than VS2015.

- Use vswhere to find the latest Visual Studio installation to use, as per https://devblogs.microsoft.com/cppblog/finding-the-visual-c-compiler-tools-in-visual-studio-2017/.
- Fallback on VS2015 if nothing is found.