### PR TITLE
Fix a System.FormatException caused by invalid format string

### DIFF
--- a/Sharpmake/Assembler.cs
+++ b/Sharpmake/Assembler.cs
@@ -461,9 +461,9 @@ namespace Sharpmake
                 foreach (CompilerError ce in cr.Errors)
                 {
                     if (ce.IsWarning)
-                        EventOutputWarning?.Invoke(ce + Environment.NewLine);
+                        EventOutputWarning?.Invoke("{0}" + Environment.NewLine, ce.ToString());
                     else
-                        EventOutputError?.Invoke(ce + Environment.NewLine);
+                        EventOutputError?.Invoke("{0}" + Environment.NewLine, ce.ToString());
 
                     errorMessage += ce + Environment.NewLine;
                 }


### PR DESCRIPTION
If compilation fails with an error such as this:

`testproj.sharpmake.cs(59,2) : error CS1513: } expected`

Shaprmake throws System.FormatException because the error format string contains a character which is considered as a special formatting character. This can be very confusing and prevents users to find the actual problem which is in their script code. 