### PR TITLE
Make sure JSON float serialization is culture invariant

### DIFF
--- a/Sharpmake.UnitTests/JsonSerializerTest.cs
+++ b/Sharpmake.UnitTests/JsonSerializerTest.cs
@@ -17,6 +17,7 @@ using System.Collections;
 using System.Collections.Generic;
 
 using NUnit.Framework;
+using System.Globalization;
 
 namespace Sharpmake.UnitTests
 {
@@ -103,6 +104,18 @@ namespace Sharpmake.UnitTests
         [Test]
         public void SerializeNegativeDouble()
         {
+            _serializer.Serialize(-13.37);
+            Assert.That(_writer.ToString(), Is.EqualTo("-13.37"));
+        }
+
+        [Test]
+        public void FloatSerializationIsNotCultureDependent()
+        {
+            // Change culture to a non-json compatible format
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("da-DK");
+            // As illustration
+            Assert.That((-13.37).ToString(), Is.EqualTo("-13,37"));
+
             _serializer.Serialize(-13.37);
             Assert.That(_writer.ToString(), Is.EqualTo("-13.37"));
         }

--- a/Sharpmake/Util.cs
+++ b/Sharpmake/Util.cs
@@ -16,6 +16,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1473,10 +1474,14 @@ namespace Sharpmake
                 return sb.ToString();
             }
 
-            private static bool IsNumber(object o)
+            private static bool IsFloat(object o)
             {
-                return o is float || o is double || o is decimal ||
-                       o is sbyte || o is short || o is int || o is long ||
+                return o is float || o is double || o is decimal;
+            }
+
+            private static bool IsInteger(object o)
+            {
+                return o is sbyte || o is short || o is int || o is long ||
                        o is byte || o is ushort || o is uint || o is ulong;
             }
 
@@ -1522,7 +1527,16 @@ namespace Sharpmake
                 {
                     SerializeArray((IEnumerable)value);
                 }
-                else if (value is bool || IsNumber(value))
+                else if (value is bool)
+                {
+                    _writer.Write(value.ToString().ToLower());
+                }
+                else if (IsFloat(value))
+                {
+                    // This *should* be safe without Escaping
+                    _writer.Write(Convert.ToDouble(value).ToString(CultureInfo.InvariantCulture));
+                }
+                else if (IsInteger(value))
                 {
                     // This *should* be safe without Escaping
                     _writer.Write(EscapeJson(value.ToString().ToLower()));


### PR DESCRIPTION
JSON float serialization currently can be affected by the default system CultureInfo.
Changed JSON serialization to use CultureInvariant when writing float types, added test.