### PR TITLE
Compile script MacOS

### DIFF
--- a/CompileSharpmake.sh
+++ b/CompileSharpmake.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Script arguments:
+# $1: Project/Solution to build
+# $2: Target(Normally should be Debug or Release)
+# $3: Platform(Normally should be "Any CPU" for sln and AnyCPU for a csproj)
+# if none are passed, defaults to building Sharpmake.sln in Debug|Any CPU
+
+function BuildSharpmake {
+    solutionPath=$1
+    configuration=$2
+    platform=$3
+    echo Compiling $solutionPath in "${configuration}|${platform}"...
+    MSBUILD_CMD="msbuild -t:build -restore \"${solutionPath}\" /nologo /v:m /p:Configuration=${configuration} /p:Platform=\"${platform}\""
+    echo $MSBUILD_CMD
+    eval $MSBUILD_CMD
+    if [ $? -ne 0 ]; then
+        echo ERROR: Failed to compile $solutionPath in "${configuration}|${platform}".
+        exit 1
+    fi
+}
+
+# fail immediately if anything goes wrong
+set -e
+
+pushd $(dirname $0) > /dev/null
+CURRENT_DIR=$(pwd)
+popd > /dev/null
+
+which msbuild > /dev/null
+MSBUILD_FOUND=$?
+if [ $MSBUILD_FOUND -ne 0 ]; then
+    echo "MSBuild not found"
+    exit $MSBUILD_FOUND
+fi
+
+SOLUTION_PATH=${1:-"${CURRENT_DIR}/Sharpmake.sln"}
+CONFIGURATION=${2:-"Debug"}
+PLATFORM=${3:-"Any CPU"}
+
+BuildSharpmake "$SOLUTION_PATH" "$CONFIGURATION" "$PLATFORM"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,26 +1,61 @@
 #!/bin/sh
 
+function pause {
+ 	read -s -n 1 -p "Press any key to continue . . ."
+ 	echo ""
+}
+
+function success {
+	echo Bootstrap succeeded \!
+	exit 0
+}
+
+function error {
+	echo Bootstrap failed \!
+	pause
+	exit 1
+}
+
 # fail immediately if anything goes wrong
 set -e
+
+pushd $(dirname $0) > /dev/null
+CURRENT_DIR=$(pwd)
+popd > /dev/null
+
+which msbuild > /dev/null
+MSBUILD_FOUND=$?
+if [ $MSBUILD_FOUND -ne 0 ]; then
+    echo "MSBuild not found"
+    error
+fi
 
 # workaround for https://github.com/mono/mono/issues/6752
 TERM=xterm
 
 # TODO: Test mono and msbuild existence
-SHARPMAKE_EXECUTABLE=$PWD/bin/debug/Sharpmake.Application.exe
+SHARPMAKE_EXECUTABLE=$CURRENT_DIR/bin/debug/Sharpmake.Application.exe
 
-SM_CMD="msbuild -t:build -restore /p:Configuration=Debug /p:Platform="AnyCPU" /v:m Sharpmake.Application/Sharpmake.Application.csproj"
-echo "Building Sharpmake..."
-echo $SM_CMD
-eval $SM_CMD
-
+sh $CURRENT_DIR/CompileSharpmake.sh Sharpmake.Application/Sharpmake.Application.csproj Debug AnyCPU
 if [ $? -ne 0 ]; then
     echo "The build has failed."
     if [ -f $SHARPMAKE_EXECUTABLE ]; then
-        echo "A previously built sharpmake exe was found at '$SHARPMAKE_EXECUTABLE', it will be reused."
+        echo "A previously built sharpmake exe was found at '${SHARPMAKE_EXECUTABLE}', it will be reused."
     fi
 fi
 
-echo "Generating Sharpmake solution..."
-mono --debug $SHARPMAKE_EXECUTABLE "/sources(\"Sharpmake.Main.sharpmake.cs\")" /verbose
+which mono > /dev/null
+MONO_FOUND=$?
+if [ $MONO_FOUND -ne 0 ]; then
+    echo "Mono not found"
+    error
+fi
 
+SHARPMAKE_MAIN=${1:-"$CURRENT_DIR/Sharpmake.Main.sharpmake.cs"}
+
+echo "Generating Sharpmake solution..."
+SM_CMD="mono --debug \"${SHARPMAKE_EXECUTABLE}\" \"/sources(\\\"${SHARPMAKE_MAIN}\\\")\" /verbose"
+echo $SM_CMD
+eval $SM_CMD || error
+
+success


### PR DESCRIPTION
Add equivalent of CompileSharpmake.bat in Bash for MacOS and adapt bootstrap.sh to call it.
Tested on MacOS 10.15.4