### PR TITLE
Fixed discrepancy in how Sharpmake determines which projects to generate between single- and multi-threaded modes

### DIFF
--- a/Sharpmake/Builder.cs
+++ b/Sharpmake/Builder.cs
@@ -281,6 +281,8 @@ namespace Sharpmake
                         {
                             _buildScheduledType.Add(projectDependenciesType);
                         }
+
+                        Arguments.TypesToGenerate.AddRange(_buildScheduledType);
                     }
                 }
                 else
@@ -291,9 +293,9 @@ namespace Sharpmake
                     }
 
                     _tasks.Wait();
+                    
+                    Arguments.TypesToGenerate.AddRange(_buildScheduledType);
                 }
-
-                Arguments.TypesToGenerate.AddRange(_buildScheduledType);
             }
         }
 


### PR DESCRIPTION
This is something I introduced when trying to fix another discrepancy bug

The for loop in Builder.cs at line 258 iterates through Arguments.TypesToGenerate. Before my previous change, this list would grow as the loop ran, ensuring all dependencies were generated. My change made it so this list never grew until the loop was finished, causing some projects to not be generated in single-threaded mode.